### PR TITLE
fix: default code blocks to language 'text'

### DIFF
--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,2 +1,5 @@
 README.md
 LICENSE.md
+
+# Ava
+.tsimp

--- a/lib/fixtures/basics.json
+++ b/lib/fixtures/basics.json
@@ -252,18 +252,6 @@
           ]
         }
       ]
-    },
-    {
-      "type": "codeBlock",
-      "attrs": {
-        "language": "typescript"
-      },
-      "content": [
-        {
-          "type": "text",
-          "text": "const hello = \"world\";\nconsole.log(hello);"
-        }
-      ]
     }
   ]
 }

--- a/lib/fixtures/code-blocks.json
+++ b/lib/fixtures/code-blocks.json
@@ -1,0 +1,42 @@
+{
+  "version": 1,
+  "type": "doc",
+  "content": [
+    {
+      "type": "codeBlock",
+      "attrs": {
+        "language": "typescript"
+      },
+      "content": [
+        {
+          "type": "text",
+          "text": "const hello = \"world\";\nconsole.log(hello);"
+        }
+      ]
+    },
+    {
+      "type": "codeBlock",
+      "attrs": {
+        "language": "bash"
+      },
+      "content": [
+        {
+          "type": "text",
+          "text": "echo \"Hello World\""
+        }
+      ]
+    },
+    {
+      "type": "codeBlock",
+      "attrs": {
+        "language": "text"
+      },
+      "content": [
+        {
+          "type": "text",
+          "text": "Some text"
+        }
+      ]
+    }
+  ]
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -59,7 +59,7 @@ function tokensToAdf(tokens?: RelaxedToken[]): AdfNode[] {
         case "code":
           return {
             type: "codeBlock",
-            attrs: { language: token.lang || null },
+            attrs: { language: token.lang || 'text' },
             content: [
               {
                 type: "text",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -59,7 +59,7 @@ function tokensToAdf(tokens?: RelaxedToken[]): AdfNode[] {
         case "code":
           return {
             type: "codeBlock",
-            attrs: { language: token.lang || 'text' },
+            attrs: { language: token.lang || "text" },
             content: [
               {
                 type: "text",

--- a/lib/package.json
+++ b/lib/package.json
@@ -9,11 +9,7 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE.md"
-  ],
+  "files": ["dist", "README.md", "LICENSE.md"],
   "keywords": [
     "markdown",
     "adf",
@@ -42,8 +38,6 @@
     "extensions": {
       "ts": "module"
     },
-    "nodeArguments": [
-      "--import=tsimp"
-    ]
+    "nodeArguments": ["--import=tsimp"]
   }
 }

--- a/lib/package.json
+++ b/lib/package.json
@@ -9,7 +9,11 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist", "README.md", "LICENSE.md"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE.md"
+  ],
   "keywords": [
     "markdown",
     "adf",
@@ -30,7 +34,16 @@
   },
   "devDependencies": {
     "ava": "^6.2.0",
+    "tsimp": "^2.0.12",
     "typescript": "^5.7.3"
   },
-  "type": "module"
+  "type": "module",
+  "ava": {
+    "extensions": {
+      "ts": "module"
+    },
+    "nodeArguments": [
+      "--import=tsimp"
+    ]
+  }
 }

--- a/lib/test.ts
+++ b/lib/test.ts
@@ -31,12 +31,7 @@ Below is an image
 1. Ordered item 1
 2. Ordered item 2
 
-> This is a blockquote
-
-\`\`\`typescript
-const hello = "world";
-console.log(hello);
-\`\`\``;
+> This is a blockquote`;
   const adf = await markdownToAdf(markdown);
   t.deepEqual(adf, basicsAdf);
 });
@@ -65,6 +60,24 @@ test(`For inline code marks only allow link marks and not other inline marks`, a
 
   const adf = await markdownToAdf(markdown);
   t.deepEqual(adf, inlineCodeAdf);
+});
+
+test(`Converts code blocks correctly`, async (t) => {
+  const markdown = `\`\`\`typescript
+const hello = "world";
+console.log(hello);
+\`\`\`
+
+\`\`\`bash
+echo "Hello World"
+\`\`\`
+
+\`\`\`
+Some text
+\`\`\``;
+
+  const adf = await markdownToAdf(markdown);
+  t.deepEqual(adf, codeBlocksAdf);
 });
 
 test(`Text edge cases are handled correctly`, async (t) => {

--- a/lib/test.ts
+++ b/lib/test.ts
@@ -1,11 +1,15 @@
-import anyTest, {type TestFn} from 'ava';
+import anyTest, { type TestFn } from "ava";
 import { markdownToAdf } from "./index";
-import basicsAdf from "./fixtures/basics.json" with { type: "json" };;
-import nestedListAdf from "./fixtures/nested-list.json" with { type: "json" };;
-import inlineCodeAdf from "./fixtures/inline-code-marks.json" with { type: "json" };;
-import codeBlocksAdf from "./fixtures/code-blocks.json" with { type: "json" };;
-import tableAdf from "./fixtures/table.json" with { type: "json" };;
-import textEdgeCases from "./fixtures/text-edge-cases.json" with { type: "json" };;
+import basicsAdf from "./fixtures/basics.json" with { type: "json" };
+import nestedListAdf from "./fixtures/nested-list.json" with { type: "json" };
+import inlineCodeAdf from "./fixtures/inline-code-marks.json" with {
+  type: "json",
+};
+import codeBlocksAdf from "./fixtures/code-blocks.json" with { type: "json" };
+import tableAdf from "./fixtures/table.json" with { type: "json" };
+import textEdgeCases from "./fixtures/text-edge-cases.json" with {
+  type: "json",
+};
 
 const test = anyTest as unknown as TestFn<void>;
 

--- a/lib/test.ts
+++ b/lib/test.ts
@@ -1,14 +1,13 @@
-import test from "ava";
-import { markdownToAdf } from "./dist/index.js";
-import basicsAdf from "./fixtures/basics.json" assert { type: "json" };
-import nestedListAdf from "./fixtures/nested-list.json" assert { type: "json" };
-import inlineCodeAdf from "./fixtures/inline-code-marks.json" assert {
-  type: "json",
-};
-import tableAdf from "./fixtures/table.json" assert { type: "json" };
-import textEdgeCases from "./fixtures/text-edge-cases.json" assert {
-  type: "json",
-};
+import anyTest, {type TestFn} from 'ava';
+import { markdownToAdf } from "./index";
+import basicsAdf from "./fixtures/basics.json" with { type: "json" };;
+import nestedListAdf from "./fixtures/nested-list.json" with { type: "json" };;
+import inlineCodeAdf from "./fixtures/inline-code-marks.json" with { type: "json" };;
+import codeBlocksAdf from "./fixtures/code-blocks.json" with { type: "json" };;
+import tableAdf from "./fixtures/table.json" with { type: "json" };;
+import textEdgeCases from "./fixtures/text-edge-cases.json" with { type: "json" };;
+
+const test = anyTest as unknown as TestFn<void>;
 
 test("Can convert basic markdown elements", async (t) => {
   const markdown = `# Hello World

--- a/lib/tsconfig.test.json
+++ b/lib/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "resolveJsonModule": true
+  },
+  "include": ["test.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,14 +17,145 @@
     },
     "lib": {
       "name": "marklassian",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "marked": "^15.0.6"
       },
       "devDependencies": {
         "ava": "^6.2.0",
+        "tsimp": "^2.0.12",
         "typescript": "^5.7.3"
+      }
+    },
+    "lib/node_modules/glob": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
+      "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "lib/node_modules/jackspeak": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
+      "integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "lib/node_modules/lru-cache": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "lib/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "lib/node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "lib/node_modules/rimraf": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "lib/node_modules/tsimp": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/tsimp/-/tsimp-2.0.12.tgz",
+      "integrity": "sha512-0XbhMfDB1BlN4iuheUaCUVB2iAjWb9z6Ik/6WcxREc4MhjYmkScK+CRNf34wkDO8wMvmFBb0lYdrd8H44g9yjg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cached": "^1.0.1",
+        "@isaacs/catcher": "^1.0.4",
+        "foreground-child": "^3.1.1",
+        "mkdirp": "^3.0.1",
+        "pirates": "^4.0.6",
+        "rimraf": "^6.0.1",
+        "signal-exit": "^4.1.0",
+        "sock-daemon": "^1.4.2",
+        "walk-up-path": "^4.0.0"
+      },
+      "bin": {
+        "tsimp": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.1.0"
       }
     },
     "lib/node_modules/typescript": {
@@ -3822,6 +3953,23 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/@isaacs/cached": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/cached/-/cached-1.0.1.tgz",
+      "integrity": "sha512-7kGcJ9Hc1f4qpTApWz3swxbF9Qv1NF/GxuPtXeTptbsgvJIoufSd0h854Nq/2bw80F5C1onsFgEI05l+q0e4vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/catcher": "^1.0.0"
+      }
+    },
+    "node_modules/@isaacs/catcher": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@isaacs/catcher/-/catcher-1.0.4.tgz",
+      "integrity": "sha512-g2klMwbnguClWNnCeQ1zYaDJsvPbIbnjdJPDE0z09MqoejJDZSLK5vIKiClq2Bkg5ubuI8vaN6wfIUi5GYzMVA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -9000,6 +9148,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/sock-daemon": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/sock-daemon/-/sock-daemon-1.4.2.tgz",
+      "integrity": "sha512-IzbegWshWWR+UzQ7487mbdYNmfJ1jXUXQBUHooqtpylO+aW0vMVbFN2d2ug3CSPZ0wbG7ZTTGwpUuthIDFIOGg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "rimraf": "^5.0.5",
+        "signal-exit": "^4.1.0",
+        "socket-post-message": "^1.0.3"
+      },
+      "engines": {
+        "node": "16 >=16.17.0 || 18 >= 18.6.0 || >=20"
+      }
+    },
+    "node_modules/socket-post-message": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/socket-post-message/-/socket-post-message-1.0.3.tgz",
+      "integrity": "sha512-UhJaB3xR2oF+HvddFOq2cBZi4zVKOHvdiBo+BaScNxsEUg3TLWSP8BkweKfe07kfH1thjn1hJR0af/w1EtBFjg==",
+      "dev": true
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -9672,6 +9841,16 @@
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
+    },
+    "node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/warning": {
       "version": "4.0.3",


### PR DESCRIPTION
This PR fixes a minor issue with code block converstion to ADF. If a markdown code block language is not specified, the library formerly set the language to `null`, which ends up being rejected as invalid by Jira's API endpoint (or at least the issue comment endpoint, in my experience). 

The fix is to fall back to `'text'` rather than `null`, which is the [default attribute for code blocks](https://developer.atlassian.com/cloud/jira/platform/apis/document/nodes/codeBlock/#attributes).

I've also taken the liberty of re-configuring the Ava setup such that it's easier to work with TypeScript source code.
