### PR TITLE
Soft line breaks before emphasis

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -255,9 +255,15 @@ function processParagraph(tokens?: RelaxedToken[]): AdfNode[] {
 
     if (token?.type === "image") {
       if (currentParagraphTokens.length) {
+        const content = inlineToAdf(currentParagraphTokens);
+        const lastNode = content.at(-1);
+        if (lastNode?.type === "text" && lastNode.text?.endsWith(" ")) {
+          lastNode.text = lastNode.text.slice(0, -1);
+        }
+
         outputNodes.push({
           type: "paragraph",
-          content: inlineToAdf(currentParagraphTokens),
+          content,
         });
         currentParagraphTokens = [];
       }
@@ -430,10 +436,7 @@ function getSafeText(token: RelaxedToken): string {
   }
 
   if ("text" in token) {
-    return token.text
-      .replace(/\n$/, "")
-      .replace(/\n/g, " ")
-      .replace(/\s+/g, " ");
+    return token.text.replace(/\n/g, " ").replace(/\s+/g, " ");
   }
 
   return "";

--- a/lib/test/core-markdown.test.ts
+++ b/lib/test/core-markdown.test.ts
@@ -102,6 +102,26 @@ Thisstringoftexthasa**strong**wordcontained.`;
   t.deepEqual(adf, textEdgeCases);
 });
 
+test(`Preserves soft line breaks before inline formatting`, (t) => {
+  const adf = markdownToAdf(
+    "**Type:** chore\n**Estimated scope:** S (1-2 files)",
+  );
+
+  t.deepEqual(adf.content[0], {
+    type: "paragraph",
+    content: [
+      { type: "text", text: "Type:", marks: [{ type: "strong" }] },
+      { type: "text", text: " chore " },
+      {
+        type: "text",
+        text: "Estimated scope:",
+        marks: [{ type: "strong" }],
+      },
+      { type: "text", text: " S (1-2 files)" },
+    ],
+  });
+});
+
 test(`Can convert tables correctly`, async (t) => {
   const markdown = `| **First Header** | Second Header |
 | ------------- | ------------- |


### PR DESCRIPTION
Marked stores a soft line break at the end of the preceding text token when the next line begins with inline formatting. Marklassian removed that terminal newline instead of normalizing it to a space, causing adjacent text to run together.

This PR preserves soft line breaks between inline nodes while retaining the existing behavior around standalone images and explicit hard breaks.

Closes #12.

## Testing

`npm run check`, `npm run build --workspace=lib`, and `npm test --workspace=lib` pass; the regression test covers the reported strong-emphasis boundary.